### PR TITLE
fix: Standardize border-radius with CSS variables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,7 @@
  * GitHub: https://github.com/banisterious/obsidian-charted-roots
  *
  * BUILD INFORMATION:
- * - Generated: 2026-01-30 22:14:44 UTC
+ * - Generated: 2026-02-03 11:06:37 UTC
  * - Components: 44 files
  * - Build System: Node.js CSS Build Script v1.0.0
  *
@@ -644,7 +644,7 @@ settings:
    COMPONENT: CONTROL-CENTER.CSS
    ========================================================================== */
 
-/* Component Size: 5747 lines, 106.74 KB */
+/* Component Size: 5747 lines, 107.88 KB */
 
 /* ==========================================================================
    Charted Roots Control Center - Styling
@@ -930,7 +930,7 @@ settings:
   align-items: center;
   gap: 4px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -1047,7 +1047,7 @@ settings:
   opacity: 0.7;
   background: var(--background-modifier-border);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-nav-item--active .crc-nav-item__meta {
@@ -1087,7 +1087,7 @@ settings:
 .crc-nav-group .crc-nav-item {
   padding: 4px 10px 3px;
   margin: 0 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-nav-group .crc-nav-item__icon {
@@ -1138,7 +1138,7 @@ settings:
 .crc-card {
   margin-top: 1em;
   background: var(--background-secondary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.12),
     0 1px 2px rgba(0, 0, 0, 0.24);
@@ -1290,7 +1290,7 @@ settings:
 .crc-root-person-selected {
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   width: 100%;
 }
@@ -1416,7 +1416,7 @@ settings:
   gap: 8px;
   padding: 8px 16px;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -1508,7 +1508,7 @@ settings:
   width: 100%;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background-color: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -1621,7 +1621,7 @@ settings:
 .crc-help-badge {
   display: inline-block;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   font-size: 11px;
@@ -1711,7 +1711,7 @@ settings:
   width: 100%;
   height: 24px;
   background: var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   overflow: hidden;
   position: relative;
 }
@@ -1721,7 +1721,7 @@ settings:
   transition:
     width 0.3s ease,
     background-color 0.3s ease;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-health-bar-fill--success {
@@ -1799,7 +1799,7 @@ settings:
 
 .crc-result-item {
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   transition: border-color 0.2s;
 }
@@ -1844,7 +1844,7 @@ settings:
   color: var(--text-muted);
   padding: 2px 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-result-item__body {
@@ -1922,7 +1922,7 @@ settings:
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
   background: var(--background-secondary);
   transition: background 0.2s ease;
@@ -1974,7 +1974,7 @@ settings:
 /* Collapsible Sections */
 .crc-collapsible {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
   overflow: hidden;
 }
@@ -2082,7 +2082,7 @@ settings:
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -2124,7 +2124,7 @@ settings:
   text-align: center;
   padding: 12px 8px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -2203,7 +2203,7 @@ settings:
   gap: 8px;
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-decoration: none;
   color: var(--text-normal);
   transition: background 0.15s ease;
@@ -2265,7 +2265,7 @@ settings:
 .crc-docs-category__links a {
   display: block;
   padding: 6px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-decoration: none;
   color: var(--text-normal);
   font-size: var(--font-ui-small);
@@ -2288,7 +2288,7 @@ settings:
 .crc-stat-box {
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   text-align: center;
 }
 
@@ -2338,7 +2338,7 @@ settings:
 .crc-progress-bar-bg {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
@@ -2346,7 +2346,7 @@ settings:
   height: 100%;
   background: var(--interactive-accent);
   transition: width 0.3s ease;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-highlights-list,
@@ -2372,7 +2372,7 @@ settings:
   width: 100%;
   height: 400px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   margin: 16px 0;
   overflow: hidden;
   background: var(--background-secondary);
@@ -2460,7 +2460,7 @@ settings:
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -2513,7 +2513,7 @@ settings:
 .crc-preview-color-scheme-select {
   font-size: 13px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
@@ -2538,7 +2538,7 @@ settings:
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -2554,7 +2554,7 @@ settings:
   right: 0;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   z-index: 100;
   min-width: 150px;
@@ -2592,7 +2592,7 @@ settings:
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   font-size: 12px;
   line-height: 1.5;
@@ -2652,7 +2652,7 @@ settings:
   margin-bottom: 1em;
   padding: 0.75em;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 /* Card title without top margin */
@@ -2708,7 +2708,7 @@ settings:
   gap: 0.75em;
   padding: 0.75em;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-stat-icon {
@@ -2757,14 +2757,14 @@ settings:
   flex: 1;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
 .cr-progress-bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -2794,7 +2794,7 @@ settings:
   margin-top: 0.75em;
   padding: 0.5em 0.75em;
   background: rgba(255, 165, 0, 0.1);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 0.9em;
 }
 
@@ -2871,7 +2871,7 @@ settings:
   align-items: center;
   padding: 0.5em;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-mini-stat-value {
@@ -2922,7 +2922,7 @@ settings:
   padding: 0.75em;
   margin-bottom: 0.5em;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   transition: background 0.15s ease;
 }
 
@@ -2981,7 +2981,7 @@ settings:
   padding: 0.4em;
   background: transparent;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   color: var(--text-muted);
   transition: all 0.15s ease;
@@ -3078,7 +3078,7 @@ settings:
   padding: 12px 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
   min-height: 70px;
@@ -3112,7 +3112,7 @@ settings:
   align-items: center;
   justify-content: center;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--interactive-accent);
 }
 
@@ -3153,7 +3153,7 @@ settings:
 .crc-template-reference-section {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
 }
 
@@ -3171,7 +3171,7 @@ settings:
 .crc-template-card {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-bottom: 12px;
 }
@@ -3198,7 +3198,7 @@ settings:
 .crc-template-code {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
   padding-right: 44px;
   margin: 0;
@@ -3224,7 +3224,7 @@ settings:
   right: 8px;
   width: 32px;
   height: 32px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   color: var(--text-muted);
@@ -3258,7 +3258,7 @@ settings:
 
 .crc-template-reference-content {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
 }
 
@@ -3288,7 +3288,7 @@ settings:
 .crc-template-var {
   background: var(--background-primary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-family: var(--font-monospace);
   font-size: 11px;
   white-space: nowrap;
@@ -3347,7 +3347,7 @@ settings:
   width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 14px;
@@ -3398,7 +3398,7 @@ settings:
   align-items: center;
   justify-content: space-between;
   padding: 6px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: background 150ms ease;
 }
 
@@ -3763,7 +3763,7 @@ settings:
 .cr-map-thumbnail {
   position: relative;
   aspect-ratio: 3/2;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   background: var(--background-secondary);
@@ -4548,7 +4548,7 @@ settings:
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -4569,7 +4569,7 @@ settings:
 
 .cr-import-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -4577,7 +4577,7 @@ settings:
 .cr-import-progress__bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }
@@ -4959,7 +4959,7 @@ settings:
 
 .cr-export-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -4967,7 +4967,7 @@ settings:
 .cr-export-progress__bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }
@@ -5017,7 +5017,7 @@ settings:
   gap: 12px;
   padding: 16px;
   margin-bottom: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -5063,7 +5063,7 @@ settings:
   max-height: 200px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -5089,7 +5089,7 @@ settings:
 
 .cr-import-success-message {
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-modifier-success);
   color: var(--text-normal);
 }
@@ -5146,7 +5146,7 @@ settings:
   max-height: 150px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-size: 12px;
 }
@@ -5210,7 +5210,7 @@ settings:
 .cr-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -5223,7 +5223,7 @@ settings:
   max-height: 250px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-size: 12px;
 }
@@ -5311,13 +5311,13 @@ settings:
   margin: 16px 0;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-flatten-progress-bar {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-top: 8px;
 }
@@ -5325,7 +5325,7 @@ settings:
 .cr-flatten-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -5350,7 +5350,7 @@ settings:
   gap: 8px;
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-flatten-result-row svg {
@@ -5371,7 +5371,7 @@ settings:
 .cr-flatten-total {
   padding: 12px;
   background: var(--background-primary-alt);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-align: center;
 }
 
@@ -5379,7 +5379,7 @@ settings:
   margin-top: 16px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -5684,7 +5684,7 @@ settings:
 
 .cr-ref-numbers-preview {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 14px;
   margin-bottom: 16px;
   font-size: 13px;
@@ -5710,7 +5710,7 @@ settings:
   padding: 12px 14px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   text-align: left;
   transition:
@@ -5798,7 +5798,7 @@ settings:
   justify-content: center;
   width: 36px;
   height: 36px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -5822,7 +5822,7 @@ settings:
   align-items: center;
   gap: 4px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -5913,7 +5913,7 @@ settings:
 
 /* Cards on mobile */
 .crc-mobile-mode .crc-card {
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-mobile-mode .crc-card__header {
@@ -5984,7 +5984,7 @@ settings:
   height: 32px;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: none;
   background: transparent;
   color: var(--text-muted);
@@ -6033,7 +6033,7 @@ settings:
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6090,7 +6090,7 @@ settings:
 .crc-reports-hub-card-icon {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6154,7 +6154,7 @@ settings:
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6211,7 +6211,7 @@ settings:
 .crc-import-export-hub-card-icon {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6400,7 +6400,7 @@ settings:
    COMPONENT: ENTITY-CREATE-MODALS.CSS
    ========================================================================== */
 
-/* Component Size: 1094 lines, 22.41 KB */
+/* Component Size: 1090 lines, 22.47 KB */
 
 /* ==========================================================================
    PERSON PICKER MODAL
@@ -6533,7 +6533,7 @@ settings:
   justify-content: space-between;
   padding: 10px 12px;
   margin-bottom: 4px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: transparent;
   color: var(--text-muted);
   font-size: 13px;
@@ -6585,7 +6585,7 @@ settings:
 .crc-picker-item {
   padding: 12px 16px;
   margin-bottom: 8px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   cursor: pointer;
@@ -6634,7 +6634,7 @@ settings:
   align-items: center;
   gap: 3px;
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: #9333ea20;
   color: #9333ea;
   font-size: 11px;
@@ -6658,7 +6658,7 @@ settings:
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;
@@ -6678,7 +6678,7 @@ settings:
   padding: 12px 16px;
   margin-top: 16px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 13px;
   font-weight: 500;
   color: var(--text-normal);
@@ -7399,11 +7399,7 @@ settings:
   bottom: 0;
   margin-top: var(--size-4-4);
   padding: var(--size-4-3) 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    var(--modal-background) 20%
-  );
+  background: linear-gradient(to bottom, transparent 0%, var(--modal-background) 20%);
   z-index: 10;
 }
 
@@ -8918,7 +8914,7 @@ settings:
    COMPONENT: MEDIA-MODALS.CSS
    ========================================================================== */
 
-/* Component Size: 1928 lines, 36.72 KB */
+/* Component Size: 1928 lines, 37.15 KB */
 
 /* ==========================================================================
    Media Picker Modal
@@ -8977,7 +8973,7 @@ settings:
   flex-direction: column;
   background: var(--background-secondary);
   border: 2px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   transition:
@@ -9028,7 +9024,7 @@ settings:
   height: 20px;
   background: var(--background-primary);
   border: 2px solid var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9193,7 +9189,7 @@ settings:
   width: 48px;
   height: 48px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -9243,7 +9239,7 @@ settings:
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition:
     color 0.15s ease,
     background-color 0.15s ease;
@@ -9267,7 +9263,7 @@ settings:
   gap: 4px;
   padding: 2px 6px;
   font-size: var(--font-ui-smaller);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
 }
@@ -9367,7 +9363,7 @@ settings:
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 
@@ -9430,7 +9426,7 @@ settings:
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9493,7 +9489,7 @@ settings:
 .crc-media-manager-card-icon {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9552,7 +9548,7 @@ settings:
   margin-top: 12px;
   padding: 4px 10px;
   background: var(--background-primary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -9625,7 +9621,7 @@ settings:
   width: 36px;
   height: 36px;
   background: rgba(96, 165, 250, 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9660,7 +9656,7 @@ settings:
   gap: 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
 }
 
@@ -9692,7 +9688,7 @@ settings:
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
   font-size: 12px;
   cursor: pointer;
@@ -9736,7 +9732,7 @@ settings:
 .crc-media-gallery-item {
   aspect-ratio: 1;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   position: relative;
@@ -9778,7 +9774,7 @@ settings:
   top: 8px;
   right: 8px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -9953,7 +9949,7 @@ settings:
   gap: 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
 }
 
@@ -9983,7 +9979,7 @@ settings:
 .crc-unlinked-media-filter-btn {
   padding: 6px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   color: var(--text-muted);
   font-size: 13px;
@@ -10015,7 +10011,7 @@ settings:
   padding: 10px 12px;
   margin-bottom: 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   flex-shrink: 0;
 }
 
@@ -10049,7 +10045,7 @@ settings:
   gap: 6px;
   padding: 6px 12px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   font-size: 13px;
@@ -10214,7 +10210,7 @@ settings:
   top: 8px;
   right: 8px;
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -10311,7 +10307,7 @@ settings:
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   flex-shrink: 0;
@@ -10409,7 +10405,7 @@ settings:
   width: 32px;
   height: 32px;
   background: rgba(139, 92, 246, 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -10437,7 +10433,7 @@ settings:
 /* Drop zone */
 .crc-upload-drop-zone {
   border: 2px dashed var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 32px 24px;
   text-align: center;
   background: var(--background-secondary);
@@ -10491,7 +10487,7 @@ settings:
   margin-bottom: 20px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid rgba(var(--interactive-accent-rgb), 0.3);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
 }
 
@@ -10542,7 +10538,7 @@ settings:
   font-size: 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-upload-file-item {
@@ -10551,7 +10547,7 @@ settings:
   gap: 10px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 12px;
   transition: all 0.15s ease;
 }
@@ -10596,7 +10592,7 @@ settings:
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: all 0.15s ease;
   flex-shrink: 0;
 }
@@ -10716,7 +10712,7 @@ settings:
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 
@@ -10784,7 +10780,7 @@ settings:
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-left: 4px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 16px;
   margin: 12px;
 }
@@ -10855,7 +10851,7 @@ settings:
    COMPONENT: IMPORT-EXPORT-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 2187 lines, 41.08 KB */
+/* Component Size: 2187 lines, 41.74 KB */
 
 /* ==========================================================================
    IMPORT/EXPORT WIZARD MODALS
@@ -11059,7 +11055,7 @@ settings:
   width: 40px;
   height: 40px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11260,7 +11256,7 @@ settings:
   width: 42px;
   height: 24px;
   background: var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   position: relative;
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -11312,7 +11308,7 @@ settings:
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
   cursor: pointer;
@@ -11347,7 +11343,7 @@ settings:
   gap: 12px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-import-folder-label,
@@ -11390,7 +11386,7 @@ settings:
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -11453,7 +11449,7 @@ settings:
 /* Export Preview section */
 .crc-export-preview-card {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -11506,7 +11502,7 @@ settings:
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-export-preview-count-icon {
@@ -11541,7 +11537,7 @@ settings:
 .crc-export-progress-bar {
   height: 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -11549,7 +11545,7 @@ settings:
 .crc-export-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -11564,7 +11560,7 @@ settings:
   max-height: 200px;
   overflow-y: auto;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   font-family: var(--font-monospace);
   font-size: 12px;
@@ -11603,7 +11599,7 @@ settings:
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
 }
@@ -11642,7 +11638,7 @@ settings:
 .crc-media-preview {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 12px;
   font-size: 12px;
 }
@@ -11712,7 +11708,7 @@ settings:
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -11775,7 +11771,7 @@ settings:
 /* Preview section */
 .crc-import-preview-card {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -11822,7 +11818,7 @@ settings:
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-import-preview-count-icon {
@@ -11853,7 +11849,7 @@ settings:
   padding: 12px 16px;
   background: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 12px;
 }
 
@@ -11912,7 +11908,7 @@ settings:
   padding: 12px 16px;
   background: rgba(248, 113, 113, 0.1);
   border: 1px solid rgba(248, 113, 113, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 12px;
 }
 
@@ -11959,7 +11955,7 @@ settings:
 .crc-import-progress-bar {
   height: 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -11967,7 +11963,7 @@ settings:
 .crc-import-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -11981,7 +11977,7 @@ settings:
 /* Import log */
 .crc-import-log {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   max-height: 200px;
   overflow-y: auto;
@@ -12055,7 +12051,7 @@ settings:
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -12118,7 +12114,7 @@ settings:
   gap: 10px;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -12196,7 +12192,7 @@ settings:
   align-items: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -12234,7 +12230,7 @@ settings:
   padding: 12px 16px;
   background: rgba(96, 165, 250, 0.1);
   border: 1px solid rgba(96, 165, 250, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-normal);
 }
 
@@ -12278,7 +12274,7 @@ settings:
   padding: 12px 16px;
   background: rgba(251, 146, 60, 0.1);
   border: 1px solid rgba(251, 146, 60, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-normal);
   text-align: center;
 }
@@ -12291,7 +12287,7 @@ settings:
   padding: 12px 16px;
   background: rgba(74, 222, 128, 0.1);
   border: 1px solid rgba(74, 222, 128, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
   color: var(--text-normal);
 }
@@ -12378,7 +12374,7 @@ settings:
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -12462,7 +12458,7 @@ settings:
   text-align: center;
   padding: 12px;
   background: var(--background-primary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-preview-stat-value {
@@ -12482,7 +12478,7 @@ settings:
 .crc-wizard-warning {
   background: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-bottom: 16px;
 }
@@ -12508,7 +12504,7 @@ settings:
 
 .crc-wizard-progress-bar-container {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   height: 8px;
   overflow: hidden;
   margin-bottom: 12px;
@@ -12517,7 +12513,7 @@ settings:
 .crc-wizard-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   transition: width 0.3s ease;
 }
 
@@ -12534,7 +12530,7 @@ settings:
 
 .crc-wizard-progress-log {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   max-height: 150px;
   overflow-y: auto;
@@ -12658,7 +12654,7 @@ settings:
 /* Wizard buttons */
 .crc-btn {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -12707,7 +12703,7 @@ settings:
   padding: 10px 14px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-selected-person-name {
@@ -12750,7 +12746,7 @@ settings:
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
 }
@@ -12772,7 +12768,7 @@ settings:
   padding: 6px 10px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
   text-align: center;
@@ -12825,7 +12821,7 @@ settings:
   margin-bottom: 16px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-private-fields-warning__item {
@@ -12856,7 +12852,7 @@ settings:
   margin-bottom: 20px;
   padding: 10px 12px;
   background: var(--background-modifier-info);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: var(--text-muted);
 }
@@ -12877,7 +12873,7 @@ settings:
 
 .cr-private-fields-warning__buttons button {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   cursor: pointer;
 }
@@ -12951,7 +12947,7 @@ settings:
   margin-bottom: 20px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-privacy-notice__feature {
@@ -12977,7 +12973,7 @@ settings:
 
 .cr-privacy-notice__buttons button {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   cursor: pointer;
 }
@@ -13013,7 +13009,7 @@ settings:
   margin-top: 16px;
   padding: 12px;
   background: var(--background-modifier-info);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 
@@ -13051,7 +13047,7 @@ settings:
    COMPONENT: STAGING-MANAGER.CSS
    ========================================================================== */
 
-/* Component Size: 555 lines, 11.21 KB */
+/* Component Size: 555 lines, 11.4 KB */
 
 /* =============================================================================
    Staging Manager Modal
@@ -13089,7 +13085,7 @@ settings:
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13137,7 +13133,7 @@ settings:
   background: var(--background-primary);
   color: var(--text-muted);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -13221,7 +13217,7 @@ settings:
   font-family: var(--font-monospace);
   background: var(--background-secondary);
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-staging-stats {
@@ -13234,7 +13230,7 @@ settings:
 .crc-staging-stat-card {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   display: flex;
   flex-direction: column;
@@ -13246,7 +13242,7 @@ settings:
   width: 32px;
   height: 32px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13320,7 +13316,7 @@ settings:
 .crc-staging-item {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 8px;
 }
@@ -13335,7 +13331,7 @@ settings:
   gap: 12px;
   margin-bottom: 12px;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin: -8px;
   padding: 8px;
   margin-bottom: 4px;
@@ -13373,7 +13369,7 @@ settings:
   width: 32px;
   height: 32px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13423,7 +13419,7 @@ settings:
   gap: 6px;
   padding: 6px 12px;
   font-size: 13px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   border: 1px solid var(--background-modifier-border);
   background: var(--background-primary);
@@ -13506,7 +13502,7 @@ settings:
   border: 1px solid var(--background-modifier-border);
   color: var(--text-normal);
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
 }
 
@@ -13536,7 +13532,7 @@ settings:
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -13577,7 +13573,7 @@ settings:
   color: var(--text-muted);
   background: var(--background-secondary);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-transform: capitalize;
   flex-shrink: 0;
 }
@@ -13615,7 +13611,7 @@ settings:
    COMPONENT: CLEANUP-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 2206 lines, 40.82 KB */
+/* Component Size: 2206 lines, 41.21 KB */
 
 /* ==========================================================================
    CLEANUP WIZARD MODAL
@@ -13688,7 +13684,7 @@ settings:
   gap: 8px;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 16px;
   font-size: 13px;
   color: var(--text-muted);
@@ -13815,7 +13811,7 @@ settings:
 .crc-cleanup-tile-badge {
   font-size: 10px;
   padding: 3px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   margin-top: 6px;
   display: inline-flex;
   align-items: center;
@@ -13996,7 +13992,7 @@ settings:
   text-align: center;
   padding: 32px;
   background: rgba(74, 222, 128, 0.1);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-cleanup-no-issues-icon {
@@ -14026,7 +14022,7 @@ settings:
   text-align: center;
   padding: 32px;
   background: rgba(74, 222, 128, 0.1);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-cleanup-step-complete-icon {
@@ -14058,7 +14054,7 @@ settings:
   color: var(--text-muted);
   font-size: 13px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 /* Preview table */
@@ -14069,7 +14065,7 @@ settings:
 
 .crc-cleanup-preview-table {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -14080,7 +14076,7 @@ settings:
   gap: 8px;
   padding: 12px 16px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
   font-size: 13px;
   color: var(--text-muted);
@@ -14240,7 +14236,7 @@ settings:
   justify-content: center;
   padding: 20px 28px;
   background: var(--background-secondary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   border: 1px solid var(--background-modifier-border);
   min-width: 100px;
 }
@@ -14284,7 +14280,7 @@ settings:
   justify-content: center;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   min-width: 80px;
   flex: 1;
@@ -14328,7 +14324,7 @@ settings:
 .crc-cleanup-category-card {
   margin-bottom: 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -14367,7 +14363,7 @@ settings:
 
 .crc-cleanup-category-badge {
   padding: 3px 10px;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   font-size: 12px;
   font-weight: 600;
   background: var(--background-modifier-border);
@@ -14412,7 +14408,7 @@ settings:
   align-items: flex-start;
   gap: 10px;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -14509,7 +14505,7 @@ settings:
   align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
 }
@@ -14637,7 +14633,7 @@ settings:
   padding: 16px;
   margin-bottom: 16px;
   background: rgba(var(--color-green-rgb), 0.1);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-cleanup-step-partial-complete .crc-cleanup-step-complete-icon {
@@ -14692,7 +14688,7 @@ settings:
   max-height: 350px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-top: 12px;
 }
 
@@ -14897,7 +14893,7 @@ settings:
   padding: 10px 12px;
   margin-top: 12px;
   background: rgba(var(--color-yellow-rgb), 0.1);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -14952,7 +14948,7 @@ settings:
   max-height: 200px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px;
   background: var(--background-secondary);
 }
@@ -15019,7 +15015,7 @@ settings:
 .crc-cleanup-geocode-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -15027,7 +15023,7 @@ settings:
 .crc-cleanup-geocode-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -15067,7 +15063,7 @@ settings:
   max-height: 200px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px;
   background: var(--background-secondary);
   margin-bottom: 16px;
@@ -15139,7 +15135,7 @@ settings:
   flex-direction: column;
   align-items: center;
   padding: 16px 24px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
 }
 
@@ -15185,7 +15181,7 @@ settings:
   max-height: 250px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 16px;
 }
 
@@ -15265,7 +15261,7 @@ settings:
   gap: 8px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 12px;
   color: var(--text-muted);
   margin-bottom: 16px;
@@ -15801,7 +15797,7 @@ settings:
 .crc-cleanup-batch-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -15809,7 +15805,7 @@ settings:
 .crc-cleanup-batch-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.2s ease;
 }
 
@@ -16052,7 +16048,7 @@ settings:
    COMPONENT: VALIDATION.CSS
    ========================================================================== */
 
-/* Component Size: 79 lines, 1.41 KB */
+/* Component Size: 79 lines, 1.46 KB */
 
 /* Validation Results Modal */
 .cr-validation-results-modal {
@@ -16065,7 +16061,7 @@ settings:
   gap: 0.5em;
   padding: 1em;
   margin-bottom: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-weight: 500;
 }
@@ -16083,7 +16079,7 @@ settings:
 
 .cr-validation-issue {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
 }
@@ -16123,7 +16119,7 @@ settings:
 .cr-validation-issue__type-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;
@@ -16140,7 +16136,7 @@ settings:
    COMPONENT: FIND-ON-CANVAS.CSS
    ========================================================================== */
 
-/* Component Size: 114 lines, 1.97 KB */
+/* Component Size: 114 lines, 2.01 KB */
 
 /* Find on Canvas Modal */
 .cr-find-on-canvas-modal {
@@ -16155,7 +16151,7 @@ settings:
 .cr-find-summary {
   padding: 1em;
   margin-bottom: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -16176,7 +16172,7 @@ settings:
 
 .cr-find-result {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -16216,7 +16212,7 @@ settings:
 .cr-find-result__badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;
@@ -16263,7 +16259,7 @@ settings:
    COMPONENT: FOLDER-SCAN.CSS
    ========================================================================== */
 
-/* Component Size: 155 lines, 2.56 KB */
+/* Component Size: 155 lines, 2.6 KB */
 
 /* Folder Scan Modal */
 .cr-folder-scan-modal {
@@ -16278,7 +16274,7 @@ settings:
 .cr-scan-summary {
   padding: 1.5em;
   margin-bottom: 1.5em;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
 }
 
@@ -16336,7 +16332,7 @@ settings:
 
 .cr-scan-result {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -16370,7 +16366,7 @@ settings:
 .cr-scan-result__badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--color-orange);
   color: white;
   font-size: 11px;
@@ -16427,7 +16423,7 @@ settings:
    COMPONENT: RELATIONSHIP-CALCULATOR.CSS
    ========================================================================== */
 
-/* Component Size: 302 lines, 5.21 KB */
+/* Component Size: 302 lines, 5.27 KB */
 
 /* ==========================================================================
    Relationship Calculator Modal
@@ -16498,7 +16494,7 @@ settings:
 /* Person Cards */
 .cr-relcalc-card {
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -16563,7 +16559,7 @@ settings:
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 12px;
@@ -16618,7 +16614,7 @@ settings:
 .cr-relcalc-result-stat {
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-align: center;
 }
 
@@ -16665,7 +16661,7 @@ settings:
 .cr-relcalc-path__node {
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -16738,7 +16734,7 @@ settings:
    COMPONENT: FAMILY-CHART-VIEW.CSS
    ========================================================================== */
 
-/* Component Size: 1282 lines, 30.12 KB */
+/* Component Size: 1282 lines, 30.15 KB */
 
 /**
  * Family Chart View Styles
@@ -17084,7 +17080,7 @@ settings:
 
 .cr-fcv-chart-container.f3 .card_image image {
   /* Ensure avatar images render with rounded corners via clip-path */
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-fcv-chart-container.f3 .card_image .genderless-icon rect {
@@ -17209,7 +17205,7 @@ settings:
   flex: 0 0 auto;
   padding: 5px;
   margin-right: 10px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .cr-fcv-chart-container.f3 div.card-image-rect svg {
@@ -18029,7 +18025,7 @@ settings:
    COMPONENT: FAMILY-CHART-EXPORT.CSS
    ========================================================================== */
 
-/* Component Size: 699 lines, 14.62 KB */
+/* Component Size: 699 lines, 14.78 KB */
 
 /* ==========================================================================
    FAMILY CHART EXPORT WIZARD
@@ -18081,7 +18077,7 @@ settings:
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   color: var(--text-muted);
   transition: all 0.15s ease;
@@ -18405,7 +18401,7 @@ settings:
   margin-top: 8px;
   padding: 6px 10px;
   background: var(--background-modifier-warning);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 12px;
   color: var(--text-warning);
 }
@@ -18478,7 +18474,7 @@ settings:
   margin-left: auto;
   padding: 4px 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -18493,7 +18489,7 @@ settings:
   margin-top: 6px;
   padding: 6px 10px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-export-hint-text {
@@ -18530,7 +18526,7 @@ settings:
 .cr-export-select {
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -18546,7 +18542,7 @@ settings:
   flex: 1;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -18570,7 +18566,7 @@ settings:
 .cr-export-scale-btn {
   padding: 6px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -18681,7 +18677,7 @@ settings:
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -18702,14 +18698,14 @@ settings:
 
 .cr-fcv-export-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
 
 .cr-fcv-export-progress__bar {
   height: 100%;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   width: var(--progress-width, 0%);
   transition: width 0.2s ease-out;
@@ -18737,7 +18733,7 @@ settings:
    COMPONENT: REPORT-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 888 lines, 19.4 KB */
+/* Component Size: 888 lines, 19.53 KB */
 
 /* ==========================================================================
    REPORT WIZARD
@@ -18982,7 +18978,7 @@ settings:
   margin-top: 4px;
   padding: 6px 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 11px;
   color: var(--text-muted);
   line-height: 1.4;
@@ -19058,7 +19054,7 @@ settings:
   margin-top: 12px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-report-types-header {
@@ -19289,7 +19285,7 @@ settings:
 .cr-report-select {
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -19305,7 +19301,7 @@ settings:
   flex: 1;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -19330,7 +19326,7 @@ settings:
   width: 100%;
   padding: 8px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -19426,7 +19422,7 @@ settings:
 
 .cr-report-estimate-panel {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px 14px;
   margin-bottom: 8px;
 }
@@ -19500,7 +19496,7 @@ settings:
   justify-content: center;
   gap: 6px;
   padding: 12px 8px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
   border: 2px solid transparent;
   cursor: pointer;
@@ -19561,7 +19557,7 @@ settings:
 .cr-report-data-quality {
   margin-top: 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   overflow: hidden;
 }
 
@@ -19634,7 +19630,7 @@ settings:
    COMPONENT: DATA-QUALITY.CSS
    ========================================================================== */
 
-/* Component Size: 1393 lines, 27.56 KB */
+/* Component Size: 1393 lines, 27.67 KB */
 
 /**
  * Data Quality Tab Styles
@@ -19749,13 +19745,13 @@ settings:
   flex: 1;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
 .crc-dq-completeness-bar {
   height: 100%;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -20265,7 +20261,7 @@ settings:
   width: 80px;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -20278,7 +20274,7 @@ settings:
 .crc-progress-bar__fill {
   height: 100%;
   background: var(--color-green);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -20834,7 +20830,7 @@ settings:
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -20850,7 +20846,7 @@ settings:
 
 .cr-place-generator-progress-bar {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -20858,7 +20854,7 @@ settings:
 .cr-place-generator-progress-bar__fill {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }
@@ -22333,7 +22329,7 @@ settings:
    COMPONENT: MAP-VIEW.CSS
    ========================================================================== */
 
-/* Component Size: 1973 lines, 40.2 KB */
+/* Component Size: 1973 lines, 40.23 KB */
 
 /* ==========================================================================
    Map View Styles
@@ -22634,7 +22630,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 /* Toolbar styles */
 .leaflet-bar {
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .leaflet-bar a {
@@ -22831,7 +22827,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-popup-content-wrapper {
   padding: 1px;
   text-align: left;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .leaflet-popup-content {
@@ -24988,7 +24984,7 @@ input[type="text"]::-webkit-input-placeholder {
    COMPONENT: EVENTS.CSS
    ========================================================================== */
 
-/* Component Size: 1515 lines, 30.63 KB */
+/* Component Size: 1515 lines, 30.67 KB */
 
 /**
  * Events Styles
@@ -25863,7 +25859,7 @@ input[type="text"]::-webkit-input-placeholder {
   flex: 1;
   height: 8px;
   background-color: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   position: relative;
   min-width: 100px;
 }
@@ -25873,7 +25869,7 @@ input[type="text"]::-webkit-input-placeholder {
   top: 0;
   height: 100%;
   background-color: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   opacity: 0.7;
 }
 
@@ -26446,7 +26442,7 @@ input[type="text"]::-webkit-input-placeholder {
   margin-bottom: 12px;
   background: hsl(var(--color-yellow-hsl) / 15%);
   border: 1px solid hsl(var(--color-yellow-hsl) / 30%);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   line-height: 1.4;
   color: var(--text-normal);
@@ -26512,7 +26508,7 @@ input[type="text"]::-webkit-input-placeholder {
    COMPONENT: TIMELINE-CALLOUTS.CSS
    ========================================================================== */
 
-/* Component Size: 321 lines, 10.66 KB */
+/* Component Size: 321 lines, 10.68 KB */
 
 /**
  * Timeline Callout Styles
@@ -26567,7 +26563,7 @@ body {
 
 .callout[data-callout="cr-timeline-outer"] {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background-color: var(--background-secondary);
   padding: var(--cr-spacing-md);
   width: var(--cr-timeline-width);
@@ -31916,7 +31912,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: DASHBOARD.CSS
    ========================================================================== */
 
-/* Component Size: 491 lines, 9.46 KB */
+/* Component Size: 491 lines, 9.64 KB */
 
 /* ==========================================================================
    Dashboard Tab Styles
@@ -31948,7 +31944,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-dashboard-tile {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   text-align: center;
   cursor: pointer;
@@ -31978,7 +31974,7 @@ body:has(.cr-media-linker) .suggestion-container {
   align-items: center;
   justify-content: center;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--interactive-accent);
 }
 
@@ -31993,7 +31989,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-dashboard-collapsible {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
 }
 
@@ -32168,7 +32164,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -32204,7 +32200,7 @@ body:has(.cr-media-linker) .suggestion-container {
   color: var(--text-muted);
   background: var(--background-primary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-transform: capitalize;
   flex-shrink: 0;
 }
@@ -32218,7 +32214,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-bottom: 16px;
   background: rgba(var(--color-yellow-rgb), 0.1);
   border: 1px solid var(--color-yellow);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-dashboard-staging-icon {
@@ -32244,7 +32240,7 @@ body:has(.cr-media-linker) .suggestion-container {
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 0.85em;
   font-weight: 500;
   cursor: pointer;
@@ -32265,7 +32261,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-bottom: 16px;
   background: rgba(var(--color-cyan-rgb), 0.1);
   border: 1px solid var(--color-cyan);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-dashboard-clipped-icon {
@@ -32291,7 +32287,7 @@ body:has(.cr-media-linker) .suggestion-container {
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 0.85em;
   font-weight: 500;
   cursor: pointer;
@@ -32331,7 +32327,7 @@ body:has(.cr-media-linker) .suggestion-container {
   gap: 12px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid var(--interactive-accent);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -32365,7 +32361,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 0;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   color: var(--text-muted);
   cursor: pointer;
   flex-shrink: 0;
@@ -32385,7 +32381,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-bottom: 16px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 
@@ -32416,7 +32412,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: UNIVERSE-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 621 lines, 11.05 KB */
+/* Component Size: 621 lines, 11.17 KB */
 
 /* ==========================================================================
    UNIVERSE SETUP WIZARD
@@ -32609,7 +32605,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .cr-wizard-details {
   margin-top: 16px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-wizard-details-header {
@@ -32667,7 +32663,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin: 8px 0;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: var(--text-muted);
   text-align: center;
@@ -32708,7 +32704,7 @@ body:has(.cr-media-linker) .suggestion-container {
   width: 100%;
   padding: 6px 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -32765,7 +32761,7 @@ body:has(.cr-media-linker) .suggestion-container {
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -32833,7 +32829,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .cr-wizard-summary-card {
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -32907,7 +32903,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-bottom: 24px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .cr-wizard-success-label {
@@ -32972,7 +32968,7 @@ body:has(.cr-media-linker) .suggestion-container {
   width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 14px;
@@ -32987,7 +32983,7 @@ body:has(.cr-media-linker) .suggestion-container {
   max-height: 300px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-file-item {
@@ -33202,7 +33198,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: FAMILY-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 743 lines, 15.52 KB */
+/* Component Size: 743 lines, 15.63 KB */
 
 /* ==========================================================================
    FAMILY CREATION WIZARD
@@ -33371,7 +33367,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-top: 16px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-picker-label {
@@ -33399,7 +33395,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-person-card-icon {
@@ -33458,7 +33454,7 @@ body:has(.cr-media-linker) .suggestion-container {
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -33492,7 +33488,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 12px;
   background: var(--background-secondary);
   border: 2px dashed var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-muted);
   cursor: pointer;
   font-size: 14px;
@@ -33572,7 +33568,7 @@ body:has(.cr-media-linker) .suggestion-container {
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-stat-value {
@@ -33771,7 +33767,7 @@ body:has(.cr-media-linker) .suggestion-container {
 
 .crc-wizard-created-notes-list {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-top: 16px;
   text-align: left;
@@ -33827,7 +33823,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-info-callout {
   background: rgb(96 165 250 / 10%);
   border: 1px solid rgb(96 165 250 / 30%);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   font-size: 13px;
   color: var(--text-muted);
@@ -33954,7 +33950,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: MAP-WIZARD.CSS
    ========================================================================== */
 
-/* Component Size: 606 lines, 12.52 KB */
+/* Component Size: 606 lines, 12.68 KB */
 
 /* ==========================================================================
    MAP CREATION WIZARD
@@ -34042,7 +34038,7 @@ body:has(.cr-media-linker) .suggestion-container {
   width: 120px;
   height: 90px;
   background: var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -34086,7 +34082,7 @@ body:has(.cr-media-linker) .suggestion-container {
   gap: 6px;
   background: var(--background-modifier-border);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -34117,7 +34113,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-top: 16px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-bounds-title {
@@ -34200,7 +34196,7 @@ body:has(.cr-media-linker) .suggestion-container {
   left: 12px;
   background: rgb(0 0 0 / 70%);
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: white;
   display: flex;
@@ -34265,7 +34261,7 @@ body:has(.cr-media-linker) .suggestion-container {
   position: absolute;
   background: var(--background-primary);
   border: 1px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
   display: flex;
   gap: 8px;
@@ -34279,7 +34275,7 @@ body:has(.cr-media-linker) .suggestion-container {
   font-size: 13px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   color: var(--text-normal);
 }
 
@@ -34325,7 +34321,7 @@ body:has(.cr-media-linker) .suggestion-container {
   gap: 12px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
 }
 
@@ -34405,7 +34401,7 @@ body:has(.cr-media-linker) .suggestion-container {
 
 .crc-wizard-summary-list {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -34491,7 +34487,7 @@ body:has(.cr-media-linker) .suggestion-container {
   gap: 4px;
   background: var(--background-modifier-border);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 13px;
   color: var(--text-normal);
 }
@@ -34547,7 +34543,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-top: 24px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-resume-preview-item {
@@ -35009,7 +35005,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: TREE-OUTPUT.CSS
    ========================================================================== */
 
-/* Component Size: 1548 lines, 30.08 KB */
+/* Component Size: 1548 lines, 30.41 KB */
 
 /* Tree Output Tab - Two-Panel Layout */
 
@@ -35041,7 +35037,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-accordion-section {
   margin-bottom: var(--cr-spacing-sm);
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   border: 1px solid var(--background-modifier-border);
 }
@@ -35175,7 +35171,7 @@ body:has(.cr-media-linker) .suggestion-container {
   display: flex;
   flex-direction: column;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   overflow: hidden;
 }
@@ -35215,7 +35211,7 @@ body:has(.cr-media-linker) .suggestion-container {
   flex-shrink: 0; /* Don't shrink the generate panel */
   background: var(--background-secondary);
   padding: var(--cr-spacing-sm) var(--cr-spacing-md);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -35323,7 +35319,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 8px 12px;
   background: var(--interactive-accent);
   color: var(--text-on-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 
@@ -35346,7 +35342,7 @@ body:has(.cr-media-linker) .suggestion-container {
   background: transparent;
   border: none;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-root-person-clear:hover {
@@ -35359,7 +35355,7 @@ body:has(.cr-media-linker) .suggestion-container {
   max-height: 250px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 4px;
 }
 
@@ -35369,7 +35365,7 @@ body:has(.cr-media-linker) .suggestion-container {
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
 }
 
@@ -35448,7 +35444,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
 }
@@ -35513,7 +35509,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-badge--small {
   font-size: 10px;
   padding: 1px 6px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-border);
   color: var(--text-muted);
 }
@@ -35567,7 +35563,7 @@ body:has(.cr-media-linker) .suggestion-container {
   gap: 8px;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
 }
 
@@ -35601,7 +35597,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 8px 12px;
   background: var(--interactive-accent);
   color: var(--text-on-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-selected-card svg {
@@ -35630,7 +35626,7 @@ body:has(.cr-media-linker) .suggestion-container {
   color: var(--text-on-accent);
   opacity: 0.7;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-wizard-clear-btn:hover {
@@ -35658,7 +35654,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 6px 10px;
   font-size: 13px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   cursor: pointer;
@@ -35690,7 +35686,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 3px 10px;
   font-size: 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   background: var(--background-primary);
   color: var(--text-muted);
   cursor: pointer;
@@ -35733,7 +35729,7 @@ body:has(.cr-media-linker) .suggestion-container {
   max-height: 180px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-person-row {
@@ -35811,7 +35807,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 6px 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
   text-align: left;
@@ -35901,7 +35897,7 @@ body:has(.cr-media-linker) .suggestion-container {
 .crc-wizard-preview-container {
   height: 270px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   overflow: hidden;
   margin-bottom: 6px;
@@ -35953,7 +35949,7 @@ body:has(.cr-media-linker) .suggestion-container {
   margin-top: var(--cr-spacing-md);
   padding: var(--cr-spacing-md);
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-summary-list {
@@ -35985,7 +35981,7 @@ body:has(.cr-media-linker) .suggestion-container {
 
 .crc-wizard-details {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   overflow: hidden;
 }
@@ -36453,7 +36449,7 @@ body:has(.cr-media-linker) .suggestion-container {
   padding: 12px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
 }
@@ -36476,7 +36472,7 @@ body:has(.cr-media-linker) .suggestion-container {
   height: 36px;
   flex-shrink: 0;
   background: var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 
@@ -36566,7 +36562,7 @@ body:has(.cr-media-linker) .suggestion-container {
    COMPONENT: DYNAMIC-CONTENT.CSS
    ========================================================================== */
 
-/* Component Size: 579 lines, 12.52 KB */
+/* Component Size: 579 lines, 12.53 KB */
 
 /**
  * Dynamic Content Styles
@@ -36973,7 +36969,7 @@ body:has(.cr-media-linker) .suggestion-container {
   background: rgb(0 0 0 / 60%);
   color: #fff;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   opacity: 0;
   z-index: 3;
   transition: opacity 0.15s ease;
@@ -37317,11 +37313,11 @@ body:has(.cr-media-linker) .suggestion-container {
    ========================================================================== */
 
 /*
- * Build completed: 2026-01-30 22:14:45 UTC
+ * Build completed: 2026-02-03 11:06:37 UTC
  * Components processed: 44
- * Total lines: 36898
- * Total size: 733.1 KB
- * Build duration: 0.93 seconds
+ * Total lines: 36894
+ * Total size: 737.61 KB
+ * Build duration: 0.01 seconds
  *
  * Component breakdown:
  * - variables.css: 56 lines, 1.61 KB
@@ -37329,43 +37325,43 @@ body:has(.cr-media-linker) .suggestion-container {
  * - base.css: 87 lines, 1.22 KB
  * - layout.css: 22 lines, 0.25 KB
  * - settings.css: 131 lines, 3.53 KB
- * - control-center.css: 5747 lines, 106.74 KB
- * - entity-create-modals.css: 1094 lines, 22.41 KB
+ * - control-center.css: 5747 lines, 107.88 KB
+ * - entity-create-modals.css: 1090 lines, 22.47 KB
  * - place-modals.css: 1406 lines, 27.04 KB
- * - media-modals.css: 1928 lines, 36.72 KB
- * - import-export-wizard.css: 2187 lines, 41.08 KB
- * - staging-manager.css: 555 lines, 11.21 KB
- * - cleanup-wizard.css: 2206 lines, 40.82 KB
+ * - media-modals.css: 1928 lines, 37.15 KB
+ * - import-export-wizard.css: 2187 lines, 41.74 KB
+ * - staging-manager.css: 555 lines, 11.4 KB
+ * - cleanup-wizard.css: 2206 lines, 41.21 KB
  * - duplicate-detection.css: 163 lines, 2.82 KB
  * - tree-statistics.css: 41 lines, 0.6 KB
- * - validation.css: 79 lines, 1.41 KB
- * - find-on-canvas.css: 114 lines, 1.97 KB
- * - folder-scan.css: 155 lines, 2.56 KB
- * - relationship-calculator.css: 302 lines, 5.21 KB
- * - family-chart-view.css: 1282 lines, 30.12 KB
- * - family-chart-export.css: 699 lines, 14.62 KB
- * - report-wizard.css: 888 lines, 19.4 KB
- * - data-quality.css: 1393 lines, 27.56 KB
+ * - validation.css: 79 lines, 1.46 KB
+ * - find-on-canvas.css: 114 lines, 2.01 KB
+ * - folder-scan.css: 155 lines, 2.6 KB
+ * - relationship-calculator.css: 302 lines, 5.27 KB
+ * - family-chart-view.css: 1282 lines, 30.15 KB
+ * - family-chart-export.css: 699 lines, 14.78 KB
+ * - report-wizard.css: 888 lines, 19.53 KB
+ * - data-quality.css: 1393 lines, 27.67 KB
  * - relationships.css: 596 lines, 11.4 KB
  * - canvas-navigation.css: 683 lines, 14.64 KB
- * - map-view.css: 1973 lines, 40.2 KB
+ * - map-view.css: 1973 lines, 40.23 KB
  * - leaflet-distortable.css: 368 lines, 7.73 KB
  * - date-systems.css: 287 lines, 5.31 KB
- * - events.css: 1515 lines, 30.63 KB
- * - timeline-callouts.css: 321 lines, 10.66 KB
+ * - events.css: 1515 lines, 30.67 KB
+ * - timeline-callouts.css: 321 lines, 10.68 KB
  * - organizations.css: 561 lines, 10.42 KB
  * - sources.css: 2832 lines, 57.42 KB
  * - statistics.css: 1654 lines, 33.24 KB
- * - dashboard.css: 491 lines, 9.46 KB
- * - universe-wizard.css: 621 lines, 11.05 KB
+ * - dashboard.css: 491 lines, 9.64 KB
+ * - universe-wizard.css: 621 lines, 11.17 KB
  * - universes.css: 41 lines, 0.73 KB
  * - collections.css: 41 lines, 0.73 KB
  * - data-quality-view.css: 47 lines, 0.89 KB
- * - family-wizard.css: 743 lines, 15.52 KB
- * - map-wizard.css: 606 lines, 12.52 KB
+ * - family-wizard.css: 743 lines, 15.63 KB
+ * - map-wizard.css: 606 lines, 12.68 KB
  * - preferences.css: 431 lines, 9.44 KB
- * - tree-output.css: 1548 lines, 30.08 KB
- * - dynamic-content.css: 579 lines, 12.52 KB
+ * - tree-output.css: 1548 lines, 30.41 KB
+ * - dynamic-content.css: 579 lines, 12.53 KB
  * - migration-notice.css: 135 lines, 2.67 KB
  * - responsive.css: 9 lines, 0.13 KB
  */

--- a/styles/cleanup-wizard.css
+++ b/styles/cleanup-wizard.css
@@ -69,7 +69,7 @@
   gap: 8px;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 16px;
   font-size: 13px;
   color: var(--text-muted);
@@ -196,7 +196,7 @@
 .crc-cleanup-tile-badge {
   font-size: 10px;
   padding: 3px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   margin-top: 6px;
   display: inline-flex;
   align-items: center;
@@ -377,7 +377,7 @@
   text-align: center;
   padding: 32px;
   background: rgba(74, 222, 128, 0.1);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-cleanup-no-issues-icon {
@@ -407,7 +407,7 @@
   text-align: center;
   padding: 32px;
   background: rgba(74, 222, 128, 0.1);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-cleanup-step-complete-icon {
@@ -439,7 +439,7 @@
   color: var(--text-muted);
   font-size: 13px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 /* Preview table */
@@ -450,7 +450,7 @@
 
 .crc-cleanup-preview-table {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -461,7 +461,7 @@
   gap: 8px;
   padding: 12px 16px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
   font-size: 13px;
   color: var(--text-muted);
@@ -621,7 +621,7 @@
   justify-content: center;
   padding: 20px 28px;
   background: var(--background-secondary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   border: 1px solid var(--background-modifier-border);
   min-width: 100px;
 }
@@ -665,7 +665,7 @@
   justify-content: center;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   min-width: 80px;
   flex: 1;
@@ -709,7 +709,7 @@
 .crc-cleanup-category-card {
   margin-bottom: 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -748,7 +748,7 @@
 
 .crc-cleanup-category-badge {
   padding: 3px 10px;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   font-size: 12px;
   font-weight: 600;
   background: var(--background-modifier-border);
@@ -793,7 +793,7 @@
   align-items: flex-start;
   gap: 10px;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -890,7 +890,7 @@
   align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
 }
@@ -1018,7 +1018,7 @@
   padding: 16px;
   margin-bottom: 16px;
   background: rgba(var(--color-green-rgb), 0.1);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-cleanup-step-partial-complete .crc-cleanup-step-complete-icon {
@@ -1073,7 +1073,7 @@
   max-height: 350px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-top: 12px;
 }
 
@@ -1278,7 +1278,7 @@
   padding: 10px 12px;
   margin-top: 12px;
   background: rgba(var(--color-yellow-rgb), 0.1);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -1333,7 +1333,7 @@
   max-height: 200px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px;
   background: var(--background-secondary);
 }
@@ -1400,7 +1400,7 @@
 .crc-cleanup-geocode-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -1408,7 +1408,7 @@
 .crc-cleanup-geocode-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -1448,7 +1448,7 @@
   max-height: 200px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px;
   background: var(--background-secondary);
   margin-bottom: 16px;
@@ -1520,7 +1520,7 @@
   flex-direction: column;
   align-items: center;
   padding: 16px 24px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
 }
 
@@ -1566,7 +1566,7 @@
   max-height: 250px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 16px;
 }
 
@@ -1646,7 +1646,7 @@
   gap: 8px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 12px;
   color: var(--text-muted);
   margin-bottom: 16px;
@@ -2182,7 +2182,7 @@
 .crc-cleanup-batch-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -2190,7 +2190,7 @@
 .crc-cleanup-batch-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.2s ease;
 }
 

--- a/styles/control-center.css
+++ b/styles/control-center.css
@@ -282,7 +282,7 @@
   align-items: center;
   gap: 4px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -399,7 +399,7 @@
   opacity: 0.7;
   background: var(--background-modifier-border);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-nav-item--active .crc-nav-item__meta {
@@ -439,7 +439,7 @@
 .crc-nav-group .crc-nav-item {
   padding: 4px 10px 3px;
   margin: 0 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-nav-group .crc-nav-item__icon {
@@ -490,7 +490,7 @@
 .crc-card {
   margin-top: 1em;
   background: var(--background-secondary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.12),
     0 1px 2px rgba(0, 0, 0, 0.24);
@@ -642,7 +642,7 @@
 .crc-root-person-selected {
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   width: 100%;
 }
@@ -768,7 +768,7 @@
   gap: 8px;
   padding: 8px 16px;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -860,7 +860,7 @@
   width: 100%;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background-color: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -973,7 +973,7 @@
 .crc-help-badge {
   display: inline-block;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   font-size: 11px;
@@ -1063,7 +1063,7 @@
   width: 100%;
   height: 24px;
   background: var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   overflow: hidden;
   position: relative;
 }
@@ -1073,7 +1073,7 @@
   transition:
     width 0.3s ease,
     background-color 0.3s ease;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .crc-health-bar-fill--success {
@@ -1151,7 +1151,7 @@
 
 .crc-result-item {
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   transition: border-color 0.2s;
 }
@@ -1196,7 +1196,7 @@
   color: var(--text-muted);
   padding: 2px 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-result-item__body {
@@ -1274,7 +1274,7 @@
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
   background: var(--background-secondary);
   transition: background 0.2s ease;
@@ -1326,7 +1326,7 @@
 /* Collapsible Sections */
 .crc-collapsible {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
   overflow: hidden;
 }
@@ -1434,7 +1434,7 @@
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -1476,7 +1476,7 @@
   text-align: center;
   padding: 12px 8px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -1555,7 +1555,7 @@
   gap: 8px;
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-decoration: none;
   color: var(--text-normal);
   transition: background 0.15s ease;
@@ -1617,7 +1617,7 @@
 .crc-docs-category__links a {
   display: block;
   padding: 6px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-decoration: none;
   color: var(--text-normal);
   font-size: var(--font-ui-small);
@@ -1640,7 +1640,7 @@
 .crc-stat-box {
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   text-align: center;
 }
 
@@ -1690,7 +1690,7 @@
 .crc-progress-bar-bg {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
@@ -1698,7 +1698,7 @@
   height: 100%;
   background: var(--interactive-accent);
   transition: width 0.3s ease;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-highlights-list,
@@ -1724,7 +1724,7 @@
   width: 100%;
   height: 400px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   margin: 16px 0;
   overflow: hidden;
   background: var(--background-secondary);
@@ -1812,7 +1812,7 @@
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -1865,7 +1865,7 @@
 .crc-preview-color-scheme-select {
   font-size: 13px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
@@ -1890,7 +1890,7 @@
   border: 1px solid var(--background-modifier-border);
   background: var(--interactive-normal);
   color: var(--text-normal);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -1906,7 +1906,7 @@
   right: 0;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   z-index: 100;
   min-width: 150px;
@@ -1944,7 +1944,7 @@
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   font-size: 12px;
   line-height: 1.5;
@@ -2004,7 +2004,7 @@
   margin-bottom: 1em;
   padding: 0.75em;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 /* Card title without top margin */
@@ -2060,7 +2060,7 @@
   gap: 0.75em;
   padding: 0.75em;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-stat-icon {
@@ -2109,14 +2109,14 @@
   flex: 1;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
 .cr-progress-bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -2146,7 +2146,7 @@
   margin-top: 0.75em;
   padding: 0.5em 0.75em;
   background: rgba(255, 165, 0, 0.1);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 0.9em;
 }
 
@@ -2223,7 +2223,7 @@
   align-items: center;
   padding: 0.5em;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-mini-stat-value {
@@ -2274,7 +2274,7 @@
   padding: 0.75em;
   margin-bottom: 0.5em;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   transition: background 0.15s ease;
 }
 
@@ -2333,7 +2333,7 @@
   padding: 0.4em;
   background: transparent;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   color: var(--text-muted);
   transition: all 0.15s ease;
@@ -2430,7 +2430,7 @@
   padding: 12px 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
   min-height: 70px;
@@ -2464,7 +2464,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--interactive-accent);
 }
 
@@ -2505,7 +2505,7 @@
 .crc-template-reference-section {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
 }
 
@@ -2523,7 +2523,7 @@
 .crc-template-card {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-bottom: 12px;
 }
@@ -2550,7 +2550,7 @@
 .crc-template-code {
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
   padding-right: 44px;
   margin: 0;
@@ -2576,7 +2576,7 @@
   right: 8px;
   width: 32px;
   height: 32px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   color: var(--text-muted);
@@ -2610,7 +2610,7 @@
 
 .crc-template-reference-content {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
 }
 
@@ -2640,7 +2640,7 @@
 .crc-template-var {
   background: var(--background-primary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-family: var(--font-monospace);
   font-size: 11px;
   white-space: nowrap;
@@ -2699,7 +2699,7 @@
   width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 14px;
@@ -2750,7 +2750,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 6px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: background 150ms ease;
 }
 
@@ -3115,7 +3115,7 @@
 .cr-map-thumbnail {
   position: relative;
   aspect-ratio: 3/2;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   background: var(--background-secondary);
@@ -3900,7 +3900,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -3921,7 +3921,7 @@
 
 .cr-import-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -3929,7 +3929,7 @@
 .cr-import-progress__bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }
@@ -4311,7 +4311,7 @@
 
 .cr-export-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -4319,7 +4319,7 @@
 .cr-export-progress__bar {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }
@@ -4369,7 +4369,7 @@
   gap: 12px;
   padding: 16px;
   margin-bottom: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -4415,7 +4415,7 @@
   max-height: 200px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -4441,7 +4441,7 @@
 
 .cr-import-success-message {
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-modifier-success);
   color: var(--text-normal);
 }
@@ -4498,7 +4498,7 @@
   max-height: 150px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-size: 12px;
 }
@@ -4562,7 +4562,7 @@
 .cr-progress-bar-container {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -4575,7 +4575,7 @@
   max-height: 250px;
   overflow-y: auto;
   padding: 8px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-size: 12px;
 }
@@ -4663,13 +4663,13 @@
   margin: 16px 0;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-flatten-progress-bar {
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-top: 8px;
 }
@@ -4677,7 +4677,7 @@
 .cr-flatten-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -4702,7 +4702,7 @@
   gap: 8px;
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-flatten-result-row svg {
@@ -4723,7 +4723,7 @@
 .cr-flatten-total {
   padding: 12px;
   background: var(--background-primary-alt);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-align: center;
 }
 
@@ -4731,7 +4731,7 @@
   margin-top: 16px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -5036,7 +5036,7 @@
 
 .cr-ref-numbers-preview {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 14px;
   margin-bottom: 16px;
   font-size: 13px;
@@ -5062,7 +5062,7 @@
   padding: 12px 14px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   text-align: left;
   transition:
@@ -5150,7 +5150,7 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -5174,7 +5174,7 @@
   align-items: center;
   gap: 4px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   color: var(--text-normal);
@@ -5265,7 +5265,7 @@
 
 /* Cards on mobile */
 .crc-mobile-mode .crc-card {
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-mobile-mode .crc-card__header {
@@ -5336,7 +5336,7 @@
   height: 32px;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: none;
   background: transparent;
   color: var(--text-muted);
@@ -5385,7 +5385,7 @@
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5442,7 +5442,7 @@
 .crc-reports-hub-card-icon {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5506,7 +5506,7 @@
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5563,7 +5563,7 @@
 .crc-import-export-hub-card-icon {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -28,7 +28,7 @@
 .crc-dashboard-tile {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   text-align: center;
   cursor: pointer;
@@ -58,7 +58,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--interactive-accent);
 }
 
@@ -73,7 +73,7 @@
 .crc-dashboard-collapsible {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
 }
 
@@ -248,7 +248,7 @@
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -284,7 +284,7 @@
   color: var(--text-muted);
   background: var(--background-primary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-transform: capitalize;
   flex-shrink: 0;
 }
@@ -298,7 +298,7 @@
   margin-bottom: 16px;
   background: rgba(var(--color-yellow-rgb), 0.1);
   border: 1px solid var(--color-yellow);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-dashboard-staging-icon {
@@ -324,7 +324,7 @@
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 0.85em;
   font-weight: 500;
   cursor: pointer;
@@ -345,7 +345,7 @@
   margin-bottom: 16px;
   background: rgba(var(--color-cyan-rgb), 0.1);
   border: 1px solid var(--color-cyan);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-dashboard-clipped-icon {
@@ -371,7 +371,7 @@
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 0.85em;
   font-weight: 500;
   cursor: pointer;
@@ -411,7 +411,7 @@
   gap: 12px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid var(--interactive-accent);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -445,7 +445,7 @@
   padding: 0;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   color: var(--text-muted);
   cursor: pointer;
   flex-shrink: 0;
@@ -465,7 +465,7 @@
   margin-bottom: 16px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 

--- a/styles/data-quality.css
+++ b/styles/data-quality.css
@@ -111,13 +111,13 @@
   flex: 1;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
 }
 
 .crc-dq-completeness-bar {
   height: 100%;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -627,7 +627,7 @@
   width: 80px;
   height: 8px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -640,7 +640,7 @@
 .crc-progress-bar__fill {
   height: 100%;
   background: var(--color-green);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -1196,7 +1196,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -1212,7 +1212,7 @@
 
 .cr-place-generator-progress-bar {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
@@ -1220,7 +1220,7 @@
 .cr-place-generator-progress-bar__fill {
   height: 100%;
   width: var(--progress-width, 0%);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   transition: width 0.2s ease-out;
 }

--- a/styles/dynamic-content.css
+++ b/styles/dynamic-content.css
@@ -403,7 +403,7 @@
   background: rgb(0 0 0 / 60%);
   color: #fff;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   opacity: 0;
   z-index: 3;
   transition: opacity 0.15s ease;

--- a/styles/entity-create-modals.css
+++ b/styles/entity-create-modals.css
@@ -129,7 +129,7 @@
   justify-content: space-between;
   padding: 10px 12px;
   margin-bottom: 4px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: transparent;
   color: var(--text-muted);
   font-size: 13px;
@@ -181,7 +181,7 @@
 .crc-picker-item {
   padding: 12px 16px;
   margin-bottom: 8px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   cursor: pointer;
@@ -230,7 +230,7 @@
   align-items: center;
   gap: 3px;
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: #9333ea20;
   color: #9333ea;
   font-size: 11px;
@@ -254,7 +254,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;
@@ -274,7 +274,7 @@
   padding: 12px 16px;
   margin-top: 16px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 13px;
   font-weight: 500;
   color: var(--text-normal);
@@ -995,11 +995,7 @@
   bottom: 0;
   margin-top: var(--size-4-4);
   padding: var(--size-4-3) 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    var(--modal-background) 20%
-  );
+  background: linear-gradient(to bottom, transparent 0%, var(--modal-background) 20%);
   z-index: 10;
 }
 

--- a/styles/events.css
+++ b/styles/events.css
@@ -871,7 +871,7 @@
   flex: 1;
   height: 8px;
   background-color: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   position: relative;
   min-width: 100px;
 }
@@ -881,7 +881,7 @@
   top: 0;
   height: 100%;
   background-color: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   opacity: 0.7;
 }
 
@@ -1454,7 +1454,7 @@
   margin-bottom: 12px;
   background: hsl(var(--color-yellow-hsl) / 15%);
   border: 1px solid hsl(var(--color-yellow-hsl) / 30%);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   line-height: 1.4;
   color: var(--text-normal);

--- a/styles/family-chart-export.css
+++ b/styles/family-chart-export.css
@@ -48,7 +48,7 @@
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
   color: var(--text-muted);
   transition: all 0.15s ease;
@@ -372,7 +372,7 @@
   margin-top: 8px;
   padding: 6px 10px;
   background: var(--background-modifier-warning);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 12px;
   color: var(--text-warning);
 }
@@ -445,7 +445,7 @@
   margin-left: auto;
   padding: 4px 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -460,7 +460,7 @@
   margin-top: 6px;
   padding: 6px 10px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-export-hint-text {
@@ -497,7 +497,7 @@
 .cr-export-select {
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -513,7 +513,7 @@
   flex: 1;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -537,7 +537,7 @@
 .cr-export-scale-btn {
   padding: 6px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -648,7 +648,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-hover);
 }
 
@@ -669,14 +669,14 @@
 
 .cr-fcv-export-progress__track {
   height: 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   overflow: hidden;
 }
 
 .cr-fcv-export-progress__bar {
   height: 100%;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--interactive-accent);
   width: var(--progress-width, 0%);
   transition: width 0.2s ease-out;

--- a/styles/family-chart-view.css
+++ b/styles/family-chart-view.css
@@ -342,7 +342,7 @@
 
 .cr-fcv-chart-container.f3 .card_image image {
   /* Ensure avatar images render with rounded corners via clip-path */
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .cr-fcv-chart-container.f3 .card_image .genderless-icon rect {
@@ -467,7 +467,7 @@
   flex: 0 0 auto;
   padding: 5px;
   margin-right: 10px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .cr-fcv-chart-container.f3 div.card-image-rect svg {

--- a/styles/family-wizard.css
+++ b/styles/family-wizard.css
@@ -165,7 +165,7 @@
   margin-top: 16px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-picker-label {
@@ -193,7 +193,7 @@
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-person-card-icon {
@@ -252,7 +252,7 @@
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -286,7 +286,7 @@
   padding: 12px;
   background: var(--background-secondary);
   border: 2px dashed var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-muted);
   cursor: pointer;
   font-size: 14px;
@@ -366,7 +366,7 @@
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-stat-value {
@@ -565,7 +565,7 @@
 
 .crc-wizard-created-notes-list {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-top: 16px;
   text-align: left;
@@ -621,7 +621,7 @@
 .crc-info-callout {
   background: rgb(96 165 250 / 10%);
   border: 1px solid rgb(96 165 250 / 30%);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   font-size: 13px;
   color: var(--text-muted);

--- a/styles/find-on-canvas.css
+++ b/styles/find-on-canvas.css
@@ -11,7 +11,7 @@
 .cr-find-summary {
   padding: 1em;
   margin-bottom: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
 }
 
@@ -32,7 +32,7 @@
 
 .cr-find-result {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -72,7 +72,7 @@
 .cr-find-result__badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;

--- a/styles/folder-scan.css
+++ b/styles/folder-scan.css
@@ -11,7 +11,7 @@
 .cr-scan-summary {
   padding: 1.5em;
   margin-bottom: 1.5em;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
 }
 
@@ -69,7 +69,7 @@
 
 .cr-scan-result {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -103,7 +103,7 @@
 .cr-scan-result__badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--color-orange);
   color: white;
   font-size: 11px;

--- a/styles/import-export-wizard.css
+++ b/styles/import-export-wizard.css
@@ -200,7 +200,7 @@
   width: 40px;
   height: 40px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -401,7 +401,7 @@
   width: 42px;
   height: 24px;
   background: var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   position: relative;
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -453,7 +453,7 @@
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
   cursor: pointer;
@@ -488,7 +488,7 @@
   gap: 12px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-import-folder-label,
@@ -531,7 +531,7 @@
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -594,7 +594,7 @@
 /* Export Preview section */
 .crc-export-preview-card {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -647,7 +647,7 @@
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-export-preview-count-icon {
@@ -682,7 +682,7 @@
 .crc-export-progress-bar {
   height: 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -690,7 +690,7 @@
 .crc-export-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -705,7 +705,7 @@
   max-height: 200px;
   overflow-y: auto;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   font-family: var(--font-monospace);
   font-size: 12px;
@@ -744,7 +744,7 @@
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
 }
@@ -783,7 +783,7 @@
 .crc-media-preview {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 12px;
   font-size: 12px;
 }
@@ -853,7 +853,7 @@
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -916,7 +916,7 @@
 /* Preview section */
 .crc-import-preview-card {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 16px;
 }
@@ -963,7 +963,7 @@
   text-align: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-import-preview-count-icon {
@@ -994,7 +994,7 @@
   padding: 12px 16px;
   background: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 12px;
 }
 
@@ -1053,7 +1053,7 @@
   padding: 12px 16px;
   background: rgba(248, 113, 113, 0.1);
   border: 1px solid rgba(248, 113, 113, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-bottom: 12px;
 }
 
@@ -1100,7 +1100,7 @@
 .crc-import-progress-bar {
   height: 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -1108,7 +1108,7 @@
 .crc-import-progress-fill {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: width 0.3s ease;
 }
 
@@ -1122,7 +1122,7 @@
 /* Import log */
 .crc-import-log {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   max-height: 200px;
   overflow-y: auto;
@@ -1196,7 +1196,7 @@
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -1259,7 +1259,7 @@
   gap: 10px;
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -1337,7 +1337,7 @@
   align-items: center;
   padding: 16px 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -1375,7 +1375,7 @@
   padding: 12px 16px;
   background: rgba(96, 165, 250, 0.1);
   border: 1px solid rgba(96, 165, 250, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-normal);
 }
 
@@ -1419,7 +1419,7 @@
   padding: 12px 16px;
   background: rgba(251, 146, 60, 0.1);
   border: 1px solid rgba(251, 146, 60, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   color: var(--text-normal);
   text-align: center;
 }
@@ -1432,7 +1432,7 @@
   padding: 12px 16px;
   background: rgba(74, 222, 128, 0.1);
   border: 1px solid rgba(74, 222, 128, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   margin-top: 16px;
   color: var(--text-normal);
 }
@@ -1519,7 +1519,7 @@
   padding: 12px 16px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -1603,7 +1603,7 @@
   text-align: center;
   padding: 12px;
   background: var(--background-primary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-preview-stat-value {
@@ -1623,7 +1623,7 @@
 .crc-wizard-warning {
   background: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 16px;
   margin-bottom: 16px;
 }
@@ -1649,7 +1649,7 @@
 
 .crc-wizard-progress-bar-container {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   height: 8px;
   overflow: hidden;
   margin-bottom: 12px;
@@ -1658,7 +1658,7 @@
 .crc-wizard-progress-bar {
   height: 100%;
   background: var(--interactive-accent);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   transition: width 0.3s ease;
 }
 
@@ -1675,7 +1675,7 @@
 
 .crc-wizard-progress-log {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px;
   max-height: 150px;
   overflow-y: auto;
@@ -1799,7 +1799,7 @@
 /* Wizard buttons */
 .crc-btn {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -1848,7 +1848,7 @@
   padding: 10px 14px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-selected-person-name {
@@ -1891,7 +1891,7 @@
   padding: 8px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
 }
@@ -1913,7 +1913,7 @@
   padding: 6px 10px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-normal);
   font-size: 13px;
   text-align: center;
@@ -1966,7 +1966,7 @@
   margin-bottom: 16px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-private-fields-warning__item {
@@ -1997,7 +1997,7 @@
   margin-bottom: 20px;
   padding: 10px 12px;
   background: var(--background-modifier-info);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: var(--text-muted);
 }
@@ -2018,7 +2018,7 @@
 
 .cr-private-fields-warning__buttons button {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   cursor: pointer;
 }
@@ -2092,7 +2092,7 @@
   margin-bottom: 20px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-privacy-notice__feature {
@@ -2118,7 +2118,7 @@
 
 .cr-privacy-notice__buttons button {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   cursor: pointer;
 }
@@ -2154,7 +2154,7 @@
   margin-top: 16px;
   padding: 12px;
   background: var(--background-modifier-info);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 

--- a/styles/map-view.css
+++ b/styles/map-view.css
@@ -297,7 +297,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 /* Toolbar styles */
 .leaflet-bar {
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .leaflet-bar a {
@@ -494,7 +494,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-popup-content-wrapper {
   padding: 1px;
   text-align: left;
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
 }
 
 .leaflet-popup-content {

--- a/styles/map-wizard.css
+++ b/styles/map-wizard.css
@@ -84,7 +84,7 @@
   width: 120px;
   height: 90px;
   background: var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -128,7 +128,7 @@
   gap: 6px;
   background: var(--background-modifier-border);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -159,7 +159,7 @@
   margin-top: 16px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-bounds-title {
@@ -242,7 +242,7 @@
   left: 12px;
   background: rgb(0 0 0 / 70%);
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: white;
   display: flex;
@@ -307,7 +307,7 @@
   position: absolute;
   background: var(--background-primary);
   border: 1px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
   display: flex;
   gap: 8px;
@@ -321,7 +321,7 @@
   font-size: 13px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   color: var(--text-normal);
 }
 
@@ -367,7 +367,7 @@
   gap: 12px;
   padding: 10px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin-bottom: 8px;
 }
 
@@ -447,7 +447,7 @@
 
 .crc-wizard-summary-list {
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
 }
 
@@ -533,7 +533,7 @@
   gap: 4px;
   background: var(--background-modifier-border);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 13px;
   color: var(--text-normal);
 }
@@ -589,7 +589,7 @@
   margin-top: 24px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-resume-preview-item {

--- a/styles/media-modals.css
+++ b/styles/media-modals.css
@@ -55,7 +55,7 @@
   flex-direction: column;
   background: var(--background-secondary);
   border: 2px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   transition:
@@ -106,7 +106,7 @@
   height: 20px;
   background: var(--background-primary);
   border: 2px solid var(--interactive-accent);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -271,7 +271,7 @@
   width: 48px;
   height: 48px;
   background: var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -321,7 +321,7 @@
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition:
     color 0.15s ease,
     background-color 0.15s ease;
@@ -345,7 +345,7 @@
   gap: 4px;
   padding: 2px 6px;
   font-size: var(--font-ui-smaller);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
 }
@@ -445,7 +445,7 @@
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 
@@ -508,7 +508,7 @@
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -571,7 +571,7 @@
 .crc-media-manager-card-icon {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -630,7 +630,7 @@
   margin-top: 12px;
   padding: 4px 10px;
   background: var(--background-primary);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -703,7 +703,7 @@
   width: 36px;
   height: 36px;
   background: rgba(96, 165, 250, 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -738,7 +738,7 @@
   gap: 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
 }
 
@@ -770,7 +770,7 @@
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
   font-size: 12px;
   cursor: pointer;
@@ -814,7 +814,7 @@
 .crc-media-gallery-item {
   aspect-ratio: 1;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   cursor: pointer;
   position: relative;
@@ -856,7 +856,7 @@
   top: 8px;
   right: 8px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1031,7 +1031,7 @@
   gap: 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 8px 12px;
 }
 
@@ -1061,7 +1061,7 @@
 .crc-unlinked-media-filter-btn {
   padding: 6px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   color: var(--text-muted);
   font-size: 13px;
@@ -1093,7 +1093,7 @@
   padding: 10px 12px;
   margin-bottom: 12px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   flex-shrink: 0;
 }
 
@@ -1127,7 +1127,7 @@
   gap: 6px;
   padding: 6px 12px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   font-size: 13px;
@@ -1292,7 +1292,7 @@
   top: 8px;
   right: 8px;
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -1389,7 +1389,7 @@
   padding: 6px 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   flex-shrink: 0;
@@ -1487,7 +1487,7 @@
   width: 32px;
   height: 32px;
   background: rgba(139, 92, 246, 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1515,7 +1515,7 @@
 /* Drop zone */
 .crc-upload-drop-zone {
   border: 2px dashed var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 32px 24px;
   text-align: center;
   background: var(--background-secondary);
@@ -1569,7 +1569,7 @@
   margin-bottom: 20px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
   border: 1px solid rgba(var(--interactive-accent-rgb), 0.3);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px;
 }
 
@@ -1620,7 +1620,7 @@
   font-size: 12px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-upload-file-item {
@@ -1629,7 +1629,7 @@
   gap: 10px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 10px 12px;
   transition: all 0.15s ease;
 }
@@ -1674,7 +1674,7 @@
   color: var(--text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   transition: all 0.15s ease;
   flex-shrink: 0;
 }
@@ -1794,7 +1794,7 @@
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 
@@ -1862,7 +1862,7 @@
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-left: 4px solid var(--interactive-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 16px;
   margin: 12px;
 }

--- a/styles/relationship-calculator.css
+++ b/styles/relationship-calculator.css
@@ -67,7 +67,7 @@
 /* Person Cards */
 .cr-relcalc-card {
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
   transition: all 0.2s ease;
@@ -132,7 +132,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 12px;
@@ -187,7 +187,7 @@
 .cr-relcalc-result-stat {
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   text-align: center;
 }
 
@@ -234,7 +234,7 @@
 .cr-relcalc-path__node {
   padding: 8px 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
 }
 

--- a/styles/report-wizard.css
+++ b/styles/report-wizard.css
@@ -241,7 +241,7 @@
   margin-top: 4px;
   padding: 6px 8px;
   background: var(--background-secondary);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   font-size: 11px;
   color: var(--text-muted);
   line-height: 1.4;
@@ -317,7 +317,7 @@
   margin-top: 12px;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-report-types-header {
@@ -548,7 +548,7 @@
 .cr-report-select {
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -564,7 +564,7 @@
   flex: 1;
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -589,7 +589,7 @@
   width: 100%;
   padding: 8px 10px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -685,7 +685,7 @@
 
 .cr-report-estimate-panel {
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 12px 14px;
   margin-bottom: 8px;
 }
@@ -759,7 +759,7 @@
   justify-content: center;
   gap: 6px;
   padding: 12px 8px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-secondary);
   border: 2px solid transparent;
   cursor: pointer;
@@ -820,7 +820,7 @@
 .cr-report-data-quality {
   margin-top: 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   overflow: hidden;
 }
 

--- a/styles/staging-manager.css
+++ b/styles/staging-manager.css
@@ -34,7 +34,7 @@
   width: 36px;
   height: 36px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -82,7 +82,7 @@
   background: var(--background-primary);
   color: var(--text-muted);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -166,7 +166,7 @@
   font-family: var(--font-monospace);
   background: var(--background-secondary);
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-staging-stats {
@@ -179,7 +179,7 @@
 .crc-staging-stat-card {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   display: flex;
   flex-direction: column;
@@ -191,7 +191,7 @@
   width: 32px;
   height: 32px;
   background: rgba(var(--interactive-accent-rgb), 0.15);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -265,7 +265,7 @@
 .crc-staging-item {
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   padding: 12px 16px;
   margin-bottom: 8px;
 }
@@ -280,7 +280,7 @@
   gap: 12px;
   margin-bottom: 12px;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   margin: -8px;
   padding: 8px;
   margin-bottom: 4px;
@@ -318,7 +318,7 @@
   width: 32px;
   height: 32px;
   background: rgba(var(--interactive-accent-rgb), 0.1);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -368,7 +368,7 @@
   gap: 6px;
   padding: 6px 12px;
   font-size: 13px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   border: 1px solid var(--background-modifier-border);
   background: var(--background-primary);
@@ -451,7 +451,7 @@
   border: 1px solid var(--background-modifier-border);
   color: var(--text-normal);
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
 }
 
@@ -481,7 +481,7 @@
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -522,7 +522,7 @@
   color: var(--text-muted);
   background: var(--background-secondary);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   text-transform: capitalize;
   flex-shrink: 0;
 }

--- a/styles/timeline-callouts.css
+++ b/styles/timeline-callouts.css
@@ -51,7 +51,7 @@ body {
 
 .callout[data-callout="cr-timeline-outer"] {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background-color: var(--background-secondary);
   padding: var(--cr-spacing-md);
   width: var(--cr-timeline-width);

--- a/styles/tree-output.css
+++ b/styles/tree-output.css
@@ -28,7 +28,7 @@
 .crc-accordion-section {
   margin-bottom: var(--cr-spacing-sm);
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   overflow: hidden;
   border: 1px solid var(--background-modifier-border);
 }
@@ -162,7 +162,7 @@
   display: flex;
   flex-direction: column;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
   overflow: hidden;
 }
@@ -202,7 +202,7 @@
   flex-shrink: 0; /* Don't shrink the generate panel */
   background: var(--background-secondary);
   padding: var(--cr-spacing-sm) var(--cr-spacing-md);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -310,7 +310,7 @@
   padding: 8px 12px;
   background: var(--interactive-accent);
   color: var(--text-on-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
 }
 
@@ -333,7 +333,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-root-person-clear:hover {
@@ -346,7 +346,7 @@
   max-height: 250px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   padding: 4px;
 }
 
@@ -356,7 +356,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   cursor: pointer;
 }
 
@@ -435,7 +435,7 @@
   padding: 8px 12px;
   background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
 }
@@ -500,7 +500,7 @@
 .crc-badge--small {
   font-size: 10px;
   padding: 1px 6px;
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   background: var(--background-modifier-border);
   color: var(--text-muted);
 }
@@ -554,7 +554,7 @@
   gap: 8px;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
 }
 
@@ -588,7 +588,7 @@
   padding: 8px 12px;
   background: var(--interactive-accent);
   color: var(--text-on-accent);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-selected-card svg {
@@ -617,7 +617,7 @@
   color: var(--text-on-accent);
   opacity: 0.7;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
 }
 
 .crc-wizard-clear-btn:hover {
@@ -645,7 +645,7 @@
   padding: 6px 10px;
   font-size: 13px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   cursor: pointer;
@@ -677,7 +677,7 @@
   padding: 3px 10px;
   font-size: 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 12px;
+  border-radius: var(--cr-radius-lg);
   background: var(--background-primary);
   color: var(--text-muted);
   cursor: pointer;
@@ -720,7 +720,7 @@
   max-height: 180px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .crc-wizard-person-row {
@@ -798,7 +798,7 @@
   padding: 6px 8px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
   text-align: left;
@@ -888,7 +888,7 @@
 .crc-wizard-preview-container {
   height: 270px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   overflow: hidden;
   margin-bottom: 6px;
@@ -940,7 +940,7 @@
   margin-top: var(--cr-spacing-md);
   padding: var(--cr-spacing-md);
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .crc-wizard-summary-list {
@@ -972,7 +972,7 @@
 
 .crc-wizard-details {
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   overflow: hidden;
 }
@@ -1440,7 +1440,7 @@
   padding: 12px;
   background: var(--background-secondary);
   border: 2px solid var(--background-modifier-border);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   cursor: pointer;
   transition: all var(--cr-transition-fast);
 }
@@ -1463,7 +1463,7 @@
   height: 36px;
   flex-shrink: 0;
   background: var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   color: var(--text-muted);
 }
 

--- a/styles/universe-wizard.css
+++ b/styles/universe-wizard.css
@@ -189,7 +189,7 @@
 .cr-wizard-details {
   margin-top: 16px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-wizard-details-header {
@@ -247,7 +247,7 @@
   margin: 8px 0;
   padding: 12px;
   background: var(--background-secondary);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 13px;
   color: var(--text-muted);
   text-align: center;
@@ -288,7 +288,7 @@
   width: 100%;
   padding: 6px 8px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 13px;
@@ -345,7 +345,7 @@
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -413,7 +413,7 @@
 .cr-wizard-summary-card {
   padding: 12px 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
   border: 1px solid var(--background-modifier-border);
 }
 
@@ -487,7 +487,7 @@
   margin-bottom: 24px;
   padding: 16px;
   background: var(--background-secondary);
-  border-radius: 8px;
+  border-radius: var(--cr-radius-md);
 }
 
 .cr-wizard-success-label {
@@ -552,7 +552,7 @@
   width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-primary);
   color: var(--text-normal);
   font-size: 14px;
@@ -567,7 +567,7 @@
   max-height: 300px;
   overflow-y: auto;
   border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
 }
 
 .cr-file-item {

--- a/styles/validation.css
+++ b/styles/validation.css
@@ -9,7 +9,7 @@
   gap: 0.5em;
   padding: 1em;
   margin-bottom: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   background: var(--background-secondary);
   font-weight: 500;
 }
@@ -27,7 +27,7 @@
 
 .cr-validation-issue {
   padding: 1em;
-  border-radius: 6px;
+  border-radius: var(--cr-radius-sm);
   border: 1px solid var(--background-modifier-border);
   background: var(--background-secondary);
 }
@@ -67,7 +67,7 @@
 .cr-validation-issue__type-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--cr-radius-xs);
   background: var(--background-modifier-border);
   color: var(--text-muted);
   font-size: 11px;

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -29,10 +29,10 @@
   --cr-border-radius: 6px;
 
   /* Border radius scale - aligns with spacing scale */
-  --cr-radius-xs: 4px;   /* Small buttons, tight items (90 usages in codebase) */
-  --cr-radius-sm: 6px;   /* Default - matches --cr-border-radius (103 usages) */
-  --cr-radius-md: 8px;   /* Medium panels, cards (91 usages) */
-  --cr-radius-lg: 12px;  /* Large containers (11 usages) */
+  --cr-radius-xs: 4px; /* Small buttons, tight items (90 usages in codebase) */
+  --cr-radius-sm: 6px; /* Default - matches --cr-border-radius (103 usages) */
+  --cr-radius-md: 8px; /* Medium panels, cards (91 usages) */
+  --cr-radius-lg: 12px; /* Large containers (11 usages) */
 
   /* Family Chart View - customizable via Style Settings plugin */
   --cr-fcv-female-color: rgb(196, 138, 146);


### PR DESCRIPTION
## Description

Replaces hardcoded `border-radius` values with CSS variables for consistency
and maintainability.

| Value | Occurrences | Variable |
|-------|-------------|----------|
| 4px | 87 | `--cr-radius-xs` |
| 6px | 104 | `--cr-radius-sm` |
| 8px | 93 | `--cr-radius-md` |
| 12px | 11 | `--cr-radius-lg` |

**Total: 295 replacements across 23 files**

**Excluded:**
- `leaflet-distortable.css` (third-party)
- `variables.css` (contains definitions)
- Special values (50%, 9999px, compound values)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated
- [x] `npm run lint:css` - pre-existing warnings only
- [x] `npm run build:css` succeeds

### Manual Testing in Obsidian
1. Deploy plugin: `npm run deploy`
2. Reload Obsidian (Cmd+R)
3. Visual inspection across multiple views:
   - Control Center tabs and cards
   - Import/Export wizard steps
   - Media modals
   - Cleanup wizard
   - Family chart view
4. Verify no visual regressions (same border radius, just from variable)
5. Test both light and dark themes

## Screenshots

N/A - no visual change expected (same values, just from variables)

## Checklist

- [x] Code follows style guidelines
- [x] Linters pass (pre-existing warnings only)
- [x] Build succeeds
- [x] Documentation updated (N/A)
- [x] Tested in Obsidian
- [x] No sensitive data in commits