### PR TITLE
fix: Remove unused d3-dag dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-	"name": "obsidian-canvas-roots",
-	"version": "0.19.20",
+	"name": "obsidian-charted-roots",
+	"version": "0.20.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-canvas-roots",
-			"version": "0.19.20",
+			"name": "obsidian-charted-roots",
+			"version": "0.20.1",
 			"license": "MIT",
 			"dependencies": {
 				"d3": "^7.9.0",
-				"d3-dag": "^1.1.0",
 				"d3-hierarchy": "^3.1.2",
 				"d3-selection": "^3.0.0",
 				"family-chart": "^0.9.0",
@@ -2690,18 +2689,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/d3-dag": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/d3-dag/-/d3-dag-1.1.0.tgz",
-			"integrity": "sha512-N8IxsIHcUaIxLrV3cElTC47kVJGFiY3blqSuJubQhyhYBJs0syfFPTnRSj2Cq0LBxxi4mzJmcqCvHIv9sPdILQ==",
-			"license": "MIT",
-			"dependencies": {
-				"d3-array": "^3.2.4",
-				"javascript-lp-solver": "0.4.24",
-				"quadprog": "^1.6.1",
-				"stringify-object": "^5.0.0"
-			}
-		},
 		"node_modules/d3-delaunay": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
@@ -4524,18 +4511,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-own-enumerable-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
-			"integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/get-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -5333,18 +5308,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-obj": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
-			"integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -5381,18 +5344,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-regexp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-			"integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-set": {
@@ -5552,12 +5503,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/javascript-lp-solver": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/javascript-lp-solver/-/javascript-lp-solver-0.4.24.tgz",
-			"integrity": "sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA==",
-			"license": "Unlicense"
 		},
 		"node_modules/jpeg-exif": {
 			"version": "1.1.4",
@@ -6677,15 +6622,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/quadprog": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/quadprog/-/quadprog-1.6.1.tgz",
-			"integrity": "sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.x"
-			}
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7617,23 +7553,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/stringify-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
-			"integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"get-own-enumerable-keys": "^1.0.0",
-				"is-obj": "^3.0.0",
-				"is-regexp": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/yeoman/stringify-object?sponsor=1"
 			}
 		},
 		"node_modules/strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 	},
 	"dependencies": {
 		"d3": "^7.9.0",
-		"d3-dag": "^1.1.0",
 		"d3-hierarchy": "^3.1.2",
 		"d3-selection": "^3.0.0",
 		"family-chart": "^0.9.0",


### PR DESCRIPTION
## Description

Removes `d3-dag` from dependencies - confirmed unused via codebase analysis.
Zero imports found across all TypeScript files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm ls d3-dag` shows "empty"

## Checklist

- [x] Code follows style guidelines
- [x] Linters pass
- [x] Build succeeds