### PR TITLE
fix: Remove unnecessary as any cast for placeType

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1013,7 +1013,7 @@ export default class CanvasRootsPlugin extends Plugin {
 						new CreatePlaceModal(this.app, {
 							directory: this.settings.placesFolder || '',
 							initialName: result.standardizedName,
-							initialPlaceType: result.placeType as any,
+							initialPlaceType: result.placeType,
 							familyGraph: this.createFamilyGraphService(),
 							placeGraph: this.createPlaceGraphService(),
 							settings: this.settings,


### PR DESCRIPTION
## Description

Removes unnecessary `as any` type cast at main.ts:1016.

**Change:**
```diff
- initialPlaceType: result.placeType as any,
+ initialPlaceType: result.placeType,
```

**Type Analysis:**
- `result.placeType` is `string | undefined`
- `CreatePlaceModal` expects `initialPlaceType?: PlaceType`
- `PlaceType` is `type PlaceType = string;`
- Types are identical - cast was never needed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `npm run lint` passes (no type errors)
- [x] `npm run build` succeeds

## Checklist

- [x] Code follows style guidelines
- [x] Linters pass
- [x] Build succeeds