### PR TITLE
fix: Add missing --cr-radius-* CSS variables

### DIFF
--- a/styles/variables.css
+++ b/styles/variables.css
@@ -28,6 +28,12 @@
   --cr-border-width: 1px;
   --cr-border-radius: 6px;
 
+  /* Border radius scale - aligns with spacing scale */
+  --cr-radius-xs: 4px;   /* Small buttons, tight items (90 usages in codebase) */
+  --cr-radius-sm: 6px;   /* Default - matches --cr-border-radius (103 usages) */
+  --cr-radius-md: 8px;   /* Medium panels, cards (91 usages) */
+  --cr-radius-lg: 12px;  /* Large containers (11 usages) */
+
   /* Family Chart View - customizable via Style Settings plugin */
   --cr-fcv-female-color: rgb(196, 138, 146);
   --cr-fcv-male-color: rgb(120, 159, 172);


### PR DESCRIPTION
## Description

Adds missing CSS radius variables that were used but never defined in
variables.css, causing styles to fail silently.

**Added variables:**
```css
--cr-radius-xs: 4px;   /* Small buttons, tight items */
--cr-radius-sm: 6px;   /* Default - matches --cr-border-radius */
--cr-radius-md: 8px;   /* Medium panels, cards */
--cr-radius-lg: 12px;  /* Large containers */
```

**Rationale:** Values based on codebase analysis of hardcoded border-radius:
- 4px: 90 occurrences
- 6px: 103 occurrences (most common)
- 8px: 91 occurrences
- 12px: 11 occurrences

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `npm run lint:css` passes
- [x] `npm run build` succeeds

## Checklist

- [x] Code follows style guidelines
- [x] Linters pass
- [x] Build succeeds